### PR TITLE
remove payload from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Objectives
 1. Write a reducer.
 2. The reducer should be a pure function.
-3. Write a reducer that takes a payload.
+3. Write a reducer that takes an action(payload).
 
 ## Overview
 
@@ -15,8 +15,7 @@ This function will be our reducer, and its job is to return to us a new state.
 ## Instructions
 
 1. In `managePresents.js`, write a function called `managePresents` that takes in an action and the previous state as its argument.
-2. In `manageFriends.js` write a function called `manageFriends` that takes in an action and the previous state as its argument.  Unlike `managePresents`, here our action will also have a property called `payload`, which is sometimes needed for producing a new state.
-  *Note: It is very common for an action to have a `payload` property in addition to `type`, but this is only a convention and there is nothing inherently special about the `payload` property.*
+2. In `manageFriends.js` write a function called `manageFriends` that takes in an action and the previous state as its argument.  Unlike `managePresents`, here our action will also have an additional property called `friends`, sometimes an action contains multiple attributes for producing a new state.
 3. Both reducers should be pure functions.  This means that the functions cannot change any object defined outside of the functions.  It also means that given an input, the reducers will always return the same output.
 
 ## A Note on the Object Spread Operator, Code from the Future

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -31,14 +31,14 @@ describe('manageFriends', function() {
     expect(manageFriends(state, {type: "ADD_FRIEND", friend: {name: 'Joe', hometown: 'Boston', id: 101}})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}]});
   })
 
-  it("removes the friend when action type is 'REMOVE_FRIEND' and the action has a property of friendId to be removed", function(){
+  it("removes the friend when action type is 'REMOVE_FRIEND' and the action has a property of the friends id to be removed", function(){
     let state = {numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]}
-    expect(manageFriends(state, {type: "REMOVE_FRIEND", friendId: 101})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Steven', hometown: 'Philadephia', id: 102}]});
+    expect(manageFriends(state, {type: "REMOVE_FRIEND", id: 101})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Steven', hometown: 'Philadephia', id: 102}]});
   })
 
   it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", function(){
     let state = {numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]}
-    manageFriends(state, {type: "REMOVE_FRIEND", payload: 'Joe'})
+    manageFriends(state, {type: "REMOVE_FRIEND", id: 101})
     expect(state).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]})
   })
 })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -3,28 +3,20 @@ import { manageFriends } from '../src/reducers/manageFriends';
 import sinon from 'sinon';
 
 describe('managePresents', () => {
-  let state = {
-    numberOfPresents: 0,
-    friends: [],
-  };
+
+  let state = { numberOfPresents: 0 };
 
   it("returns the existing state if the action's type doesn't match a type in the reducer", () => {
     expect(managePresents(state, { type: 'Random Action Type' })).toEqual(state);
   });
 
   it("increases the number of presents if there the action's type is 'INCREASE'", () =>{
-    expect(managePresents(state, { type: "INCREASE" })).toEqual({
-      numberOfPresents: 1,
-      friends: []
-    });
+    expect(managePresents(state, { type: "INCREASE" })).toEqual({ numberOfPresents: 1 });
   });
 
   it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", () =>{
     managePresents(state, { type: "INCREASE" });
-    expect(state).toEqual({
-      numberOfPresents: 0,
-      friends: [],
-    });
+    expect(state).toEqual({ numberOfPresents: 0 });
   })
 })
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,44 +1,157 @@
 import { managePresents } from '../src/reducers/managePresents';
 import { manageFriends } from '../src/reducers/manageFriends';
-import sinon        from 'sinon';
+import sinon from 'sinon';
 
-describe('managePresents', function() {
+describe('managePresents', () => {
+  let state = {
+    numberOfPresents: 0,
+    friends: [],
+  };
 
-  let state = {numberOfPresents: 0, friends: []}
+  it("returns the existing state if the action's type doesn't match a type in the reducer", () => {
+    expect(managePresents(state, { type: 'Random Action Type' })).toEqual(state);
+  });
 
-  it("returns the existing state if the action's type doesn't match a type in the reducer", function() {
-    expect(managePresents(state, {type: 'Random Action Type'})).toEqual(state);
-  })
+  it("increases the number of presents if there the action's type is 'INCREASE'", () =>{
+    expect(managePresents(state, { type: "INCREASE" })).toEqual({
+      numberOfPresents: 1,
+      friends: []
+    });
+  });
 
-  it("increases the number of presents if there the action's type is 'INCREASE'", function(){
-    expect(managePresents(state, {type: "INCREASE"})).toEqual({numberOfPresents: 1});
-  })
-
-  it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", function(){
-    managePresents(state, {type: "INCREASE"})
-    expect(state).toEqual({numberOfPresents: 0, friends: []})
-  })
-})
-
-describe('manageFriends', function() {
-  let state = {numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}]}
-
-  it("returns the existing state if the action's type doesn't match a type in the reducer", function() {
-    expect(manageFriends(state, {type: 'Random Action Type'})).toEqual(state);
-  })
-
-  it("adds the friend when type is 'ADD_FRIEND' and the action has a friend property with a name, hometown and id", function(){
-    expect(manageFriends(state, {type: "ADD_FRIEND", friend: {name: 'Joe', hometown: 'Boston', id: 101}})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}]});
-  })
-
-  it("removes the friend when action type is 'REMOVE_FRIEND' and the action has a property of the friends id to be removed", function(){
-    let state = {numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]}
-    expect(manageFriends(state, {type: "REMOVE_FRIEND", id: 101})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Steven', hometown: 'Philadephia', id: 102}]});
-  })
-
-  it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", function(){
-    let state = {numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]}
-    manageFriends(state, {type: "REMOVE_FRIEND", id: 101})
-    expect(state).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]})
+  it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", () =>{
+    managePresents(state, { type: "INCREASE" });
+    expect(state).toEqual({
+      numberOfPresents: 0,
+      friends: [],
+    });
   })
 })
+
+describe('manageFriends', () => {
+  let state = {
+    numberOfPresents: 0,
+    friends: [
+      {
+        name: 'Avi',
+        hometown: 'NYC',
+        id: 100
+      }
+    ],
+  };
+
+  it("returns the existing state if the action's type doesn't match a type in the reducer", () => {
+    expect(manageFriends(state, { type: 'Random Action Type' })).toEqual(state);
+  });
+
+  it("adds the friend when type is 'ADD_FRIEND' and the action has a friend property with a name, hometown and id", () =>{
+    expect(manageFriends(state, {
+      type: "ADD_FRIEND",
+      friend: {
+        name: 'Joe',
+        hometown: 'Boston',
+        id: 101
+      }
+    })).toEqual({
+      numberOfPresents: 0,
+      friends: [
+        {
+          name: 'Avi',
+          hometown: 'NYC',
+          id: 100
+        },
+        {
+          name: 'Joe',
+          hometown: 'Boston',
+          id: 101
+        }
+      ]
+    });
+  });
+
+  it("removes the friend when action type is 'REMOVE_FRIEND' and the action has a property of the friends id to be removed", () =>{
+    let state = {
+      numberOfPresents: 0,
+      friends: [
+        {
+          name: 'Avi',
+          hometown: 'NYC',
+          id: 100
+        },
+        {
+          name: 'Joe',
+          hometown: 'Boston',
+          id: 101
+        },
+        {
+          name: 'Steven',
+          hometown: 'Philadephia',
+          id: 102
+        }
+      ]
+    };
+
+    expect(manageFriends(state, {
+      type: "REMOVE_FRIEND",
+      id: 101
+    })).toEqual({
+      numberOfPresents: 0,
+      friends: [
+        {
+          name: 'Avi',
+          hometown: 'NYC',
+          id: 100
+        },
+        {
+          name: 'Steven',
+          hometown: 'Philadephia',
+          id: 102
+        }
+      ]
+    });
+  });
+
+  it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", () =>{
+    let state = {
+      numberOfPresents: 0,
+      friends: [
+        {
+          name: 'Avi',
+          hometown: 'NYC',
+          id: 100
+        },
+        {
+          name: 'Joe',
+          hometown: 'Boston',
+          id: 101
+        },
+        {
+          name: 'Steven',
+          hometown: 'Philadephia',
+          id: 102
+        }
+      ]
+    };
+    manageFriends(state, { type: "REMOVE_FRIEND", id: 101 });
+    expect(state).toEqual({
+      numberOfPresents: 0,
+      friends: [
+        {
+          name: 'Avi',
+          hometown: 'NYC',
+          id: 100
+        },
+        {
+          name: 'Joe',
+          hometown: 'Boston',
+          id: 101
+        },
+        {
+          name: 'Steven',
+          hometown: 'Philadephia',
+          id: 102
+        }
+      ]
+    });
+  });
+});

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -27,13 +27,13 @@ describe('manageFriends', function() {
     expect(manageFriends(state, {type: 'Random Action Type'})).toEqual(state);
   })
 
-  it("adds the friend when type is 'ADD_FRIEND' and the action has a payload property with the friend", function(){
-    expect(manageFriends(state, {type: "ADD_FRIEND", payload: {name: 'Joe', hometown: 'Boston', id: 101}})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}]});
+  it("adds the friend when type is 'ADD_FRIEND' and the action has a friend property with a name, hometown and id", function(){
+    expect(manageFriends(state, {type: "ADD_FRIEND", friend: {name: 'Joe', hometown: 'Boston', id: 101}})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}]});
   })
 
-  it("removes the friend when action type is 'REMOVE_FRIEND' and the action has a payload property of the friend's id to be removed", function(){
+  it("removes the friend when action type is 'REMOVE_FRIEND' and the action has a property of friendId to be removed", function(){
     let state = {numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Joe', hometown: 'Boston', id: 101}, {name: 'Steven', hometown: 'Philadephia', id: 102}]}
-    expect(manageFriends(state, {type: "REMOVE_FRIEND", payload: 101})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Steven', hometown: 'Philadephia', id: 102}]});
+    expect(manageFriends(state, {type: "REMOVE_FRIEND", friendId: 101})).toEqual({numberOfPresents: 0, friends: [{name: 'Avi', hometown: 'NYC', id: 100}, {name: 'Steven', hometown: 'Philadephia', id: 102}]});
   })
 
   it("adheres to the rules of being a pure function, by not changing the original state, and instead returning a new object", function(){


### PR DESCRIPTION
@talum @JeffKatzy So this pattern of using payloads in an action are a bit of an anti-pattern that I have seen in some of the redux curriculum at learn and not one I would recommend using. I've never seen it at the two jobs I've worked at where we used Redux and React. It also seems counterintuitive, because an action is already a payload of information and we are adding unnecessary nesting inside of a JavaScript Object. Dan Abramov defines an actions as, "Actions are payloads of information that send data from your application to your store." The Redux team also never uses the nested attribute of payload once in their documentation.